### PR TITLE
Move Docker registry client from the core library to the server app.

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -10,8 +10,5 @@ libraryDependencies ++= Seq(
   "com.amazonaws"              % "aws-java-sdk-ec2" % awsSdkVersion,
   "com.amazonaws"              % "aws-java-sdk-ssm" % awsSdkVersion,
   "com.typesafe.scala-logging" %% "scala-logging"   % "3.5.0",
-  "org.apache.httpcomponents"  % "httpclient"       % "4.5.2",
-  "com.github.pathikrit"       %% "better-files"    % "2.16.0",
-  "io.sphere"                  %% "sphere-json"     % "0.6.8",
   "org.scalatest"              %% "scalatest"       % "3.0.1" % "test"
 )

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -121,7 +121,7 @@ You can also disable only one rule, by specifying its rule id:
   <check level="error" class="org.scalastyle.scalariform.ImportOrderChecker" enabled="true">
     <parameters>
       <parameter name="groups">flint,java,scala,akka,com,io,net,org,better,configs,play,rx,scalaz</parameter>
-      <parameter name="group.flint">(aws\..*)|(flint\..*)|(messaging\..*)|(mock\..*)|(server\..*)|(service\..*)</parameter>
+      <parameter name="group.flint">(aws\..*)|(docker\..*)|(flint\..*)|(messaging\..*)|(mock\..*)|(server\..*)|(service\..*)</parameter>
       <parameter name="group.java">javax?\..*</parameter>
       <parameter name="group.scala">scala\..*</parameter>
       <parameter name="group.akka">_root_\.akka\..*</parameter>

--- a/server/build.sbt
+++ b/server/build.sbt
@@ -13,11 +13,14 @@ connectInput := true
 val log4jVersion = "2.7"
 
 libraryDependencies ++= Seq(
-  "com.typesafe.akka"        %% "akka-http-core"  % "10.0.1",
-  "org.apache.logging.log4j" % "log4j-api"        % log4jVersion % "runtime",
-  "org.apache.logging.log4j" % "log4j-core"       % log4jVersion % "runtime",
-  "org.apache.logging.log4j" % "log4j-1.2-api"    % log4jVersion % "runtime",
-  "org.apache.logging.log4j" % "log4j-slf4j-impl" % log4jVersion % "runtime"
+  "com.typesafe.akka"         %% "akka-http-core"  % "10.0.1",
+  "org.apache.logging.log4j"  % "log4j-api"        % log4jVersion % "runtime",
+  "org.apache.logging.log4j"  % "log4j-core"       % log4jVersion % "runtime",
+  "org.apache.logging.log4j"  % "log4j-1.2-api"    % log4jVersion % "runtime",
+  "org.apache.logging.log4j"  % "log4j-slf4j-impl" % log4jVersion % "runtime",
+  "org.apache.httpcomponents" % "httpclient"       % "4.5.2",
+  "com.github.pathikrit"      %% "better-files"    % "2.16.0",
+  "io.sphere"                 %% "sphere-json"     % "0.6.8"
 )
 
 lazy val Schema = config("schema").extend(Compile).hide

--- a/server/src/main/scala/flint/docker/Tags.scala
+++ b/server/src/main/scala/flint/docker/Tags.scala
@@ -1,5 +1,4 @@
 package flint
-package service
 package docker
 
 import io.sphere.json.{ fromJSON, JSON }

--- a/server/src/main/scala/flint/server/FlintServer.scala
+++ b/server/src/main/scala/flint/server/FlintServer.scala
@@ -1,9 +1,9 @@
 package flint
 package server
 
+import docker.Token
 import messaging.akka.AkkaServer
 import service.aws.AwsClusterService
-import service.docker.Token
 import service.mock.MockClusterService
 
 import _root_.akka.actor.ActorSystem

--- a/server/src/main/scala/flint/server/messaging/akka/AkkaServer.scala
+++ b/server/src/main/scala/flint/server/messaging/akka/AkkaServer.scala
@@ -3,8 +3,8 @@ package server
 package messaging
 package akka
 
+import docker.{ Credentials, Tags }
 import service.ClusterService
-import service.docker.{ Credentials, Tags }
 
 import java.net.URI
 


### PR DESCRIPTION
This allows us to migrate the sphere-json, httpcomponents and betterfiles library dependencies out of the core library.