### PR TITLE
[UI] Remove expired clusters or workers from UI

### DIFF
--- a/core/src/main/scala/flint/service/ClusterSystem.scala
+++ b/core/src/main/scala/flint/service/ClusterSystem.scala
@@ -13,5 +13,5 @@ trait ClusterSystem {
   }
 
   final val newClusters: Rx[Seq[ManagedCluster]] = Var(Seq.empty[ManagedCluster])
-  final val removedClusters: Rx[Seq[ClusterId]] = Var(Seq.empty[ClusterId])
+  final val removedClusters: Rx[Seq[ClusterId]]  = Var(Seq.empty[ClusterId])
 }

--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -141,8 +141,10 @@ export default class App extends React.Component {
                 const clusterToUpdate = R.prop(clusterId, clusters);
                 const updatedCluster = R.assoc(
                     "workers",
-                    R.reject(worker => R.contains(R.prop("id", worker), removedWorkerIds),
-                        R.prop("workers", clusterToUpdate)),
+                    R.reject(
+                        worker => R.contains(R.prop("id", worker), removedWorkerIds),
+                        R.prop("workers", clusterToUpdate)
+                    ),
                     clusterToUpdate
                 );
 


### PR DESCRIPTION
Remove clusters or workers from the UI when `ClustersRemoved` or `WorkersRemoved` messages are received from the server, respectively