### PR TITLE
Initialize ClusterDialog owner state to the default owner

### DIFF
--- a/ui/src/components/ClusterDialog.js
+++ b/ui/src/components/ClusterDialog.js
@@ -28,6 +28,7 @@ const generateInstanceSpec =
 
 export default class ClusterDialog extends React.Component {
     state = {
+        owner: this.props.defaultOwner,
         tags: [],
         lifetimeHoursErrorText: "",
         workerCountErrorText: "",
@@ -137,7 +138,7 @@ export default class ClusterDialog extends React.Component {
     }
 
     render() {
-        const { instanceSpecs, ownerDataSource = [], defaultOwner, openState, close } = this.props;
+        const { instanceSpecs, ownerDataSource = [], openState, close } = this.props;
 
         const clusterDialogActions = [
             <FlatButton
@@ -194,7 +195,7 @@ export default class ClusterDialog extends React.Component {
                         <Cell>
                             <AutoComplete
                                 dataSource={ownerDataSource}
-                                searchText={defaultOwner}
+                                searchText={this.state.owner}
                                 onNewRequest={this.handleOwnerChange}
                                 onUpdateInput={this.handleOwnerChange}
                                 style={fieldStyles}


### PR DESCRIPTION
Initialize ClusterDialog owner state to the default owner, and bind the search text of the owner AutoComplete to that state. Setting the `searchText` to `defaultOwner` wasn't enough to actually set the component's `owner` state.

This appears to work fuh realz.