### PR TITLE
[UI] Don't show hourly cluster cost in the UI for spot clusters

### DIFF
--- a/ui/src/components/Cluster.js
+++ b/ui/src/components/Cluster.js
@@ -157,8 +157,9 @@ export default class Cluster extends React.Component {
                             instanceSpecs={instanceSpecs}
                             masterInstanceType={master.instanceType}
                             workerInstanceType={workerInstanceType}
+                            numMasters={master.containerState === "ContainerRunning" ? 1 : 0}
                             numWorkers={getActiveWorkerCount(workers)}
-                            active={true}
+                            isSpotCluster={isSpotCluster}
                         />
                     </CardActions>
                 </Card>

--- a/ui/src/components/ClusterTotals.js
+++ b/ui/src/components/ClusterTotals.js
@@ -33,17 +33,17 @@ export default class ClusterTotals extends React.Component {
         return totalStorageBytes / (2 ** 30);
     }
 
-    calculateTotalCostPerHour = (masterInstanceTypeInfo, workerInstanceTypeInfo, numWorkers) => {
+    calculateTotalCostPerHour = (masterInstanceTypeInfo, workerInstanceTypeInfo, numMasters, numWorkers) => {
         const { hourlyPrice: masterInstanceTypeCostPerHour } = masterInstanceTypeInfo;
         const { hourlyPrice: workerInstanceTypeCostPerHour } = workerInstanceTypeInfo;
 
         const totalCost =
-            masterInstanceTypeCostPerHour + (workerInstanceTypeCostPerHour * numWorkers);
+            (masterInstanceTypeCostPerHour * numMasters) + (workerInstanceTypeCostPerHour * numWorkers);
 
         return totalCost.toFixed(2);
     }
 
-    updateClusterTotals = ({ instanceSpecs, masterInstanceType, workerInstanceType, numWorkers }) => {
+    updateClusterTotals = ({ instanceSpecs, masterInstanceType, workerInstanceType, numMasters, numWorkers }) => {
         const masterInstanceTypeInfo = this.getInstanceInfo(instanceSpecs, masterInstanceType);
         const workerInstanceTypeInfo = this.getInstanceInfo(instanceSpecs, workerInstanceType);
 
@@ -63,6 +63,7 @@ export default class ClusterTotals extends React.Component {
             totalCostPerHour: this.calculateTotalCostPerHour(
                 masterInstanceTypeInfo,
                 workerInstanceTypeInfo,
+                numMasters,
                 numWorkers,
             ),
         });
@@ -87,14 +88,14 @@ export default class ClusterTotals extends React.Component {
     }
 
     render() {
-        const { active } =  this.props;
+        const { isSpotCluster } =  this.props;
         const { numberOfCores, ramAmount, storageAmount, totalCostPerHour } = this.state;
         return (
             <Toolbar style={{ backgroundColor: "#F5F5F5" }}>
                 <ToolbarGroup style={{ paddingLeft: "24px" }} firstChild={true}>
                     <p>
                         {numberOfCores} cores, {ramAmount} GiB RAM, {storageAmount} GiB Scratch
-                        {active ? `, $${totalCostPerHour}/hour` : "" }
+                        {isSpotCluster ? "" : `, $${totalCostPerHour}/hour` }
                     </p>
                 </ToolbarGroup>
             </Toolbar>


### PR DESCRIPTION
[UI] Don't show hourly cluster cost in the UI for spot clusters. The numbers are just plain wrong