### PR TITLE
[UI] Don't touch the ClusterDialog state in componentWillReceiveProps unless it hasn't been initialized

### DIFF
--- a/ui/src/components/ClusterDialog.js
+++ b/ui/src/components/ClusterDialog.js
@@ -96,16 +96,21 @@ export default class ClusterDialog extends React.Component {
         this.props.close(owner);
     }
 
-    componentWillReceiveProps() {
-        const defaultInstance = R.pathOr("", ["instanceSpecs", 0, "instanceType"], this.props);
-        const defaultWorkerBidPrice =
-            parseFloat(R.pathOr("", ["instanceSpecs", 0, "hourlyPrice"], this.props));
-        this.setState({
-            tag: this.props.tags[0],
-            masterInstanceType: defaultInstance,
-            workerInstanceType: defaultInstance,
-            workerBidPriceString: defaultWorkerBidPrice.toString(),
-        });
+    componentWillReceiveProps(nextProps) {
+        if (this.state.tag === "" ||
+            this.state.masterInstanceType === "" ||
+            this.state.workerInstanceType === "" ||
+            this.state.workerBidPriceString === "") {
+            const defaultInstance = R.pathOr("", ["instanceSpecs", 0, "instanceType"], nextProps);
+            const defaultWorkerBidPrice =
+                parseFloat(R.pathOr("", ["instanceSpecs", 0, "hourlyPrice"], nextProps));
+            this.setState({
+                tag: nextProps.tags[0],
+                masterInstanceType: defaultInstance,
+                workerInstanceType: defaultInstance,
+                workerBidPriceString: defaultWorkerBidPrice.toString(),
+            });
+        }
     }
 
     onLifetimeHoursCountError = (error) => {


### PR DESCRIPTION
[UI] Don't touch the ClusterDialog state in componentWillReceiveProps unless it hasn't been initialized. This addresses an issue where certain form fields and dropdowns were being reset every time the list of clusters changed.