### PR TITLE
OPS-170 :: system user creation for instances based on IAM role

### DIFF
--- a/core/src/main/resources/user_data-common.sh.template
+++ b/core/src/main/resources/user_data-common.sh.template
@@ -97,4 +97,7 @@ aws ec2 create-tags --resources \$instance_id \
          Key=%CONTAINER_STATE_TAG_KEY%,Value=%CONTAINER_PENDING_STATE_TAG_VALUE%
 /usr/bin/time docker pull \$image 2> /tmp/docker_pull_time.txt
 
+# install keymaker 
+curl -L https://s3.amazonaws.com/ops.videoamp.com/scripts/install-keymaker.sh | sudo bash
+
 EOF


### PR DESCRIPTION
Adds a Keymaker installer to the `user_data-common.sh.template` template file.